### PR TITLE
added null check.

### DIFF
--- a/lib/src/com/jfeinstein/jazzyviewpager/JazzyViewPager.java
+++ b/lib/src/com/jfeinstein/jazzyviewpager/JazzyViewPager.java
@@ -559,6 +559,9 @@ public class JazzyViewPager extends ViewPager {
 	
 	private View findViewFromObject(int position) {
 		Object o = mObjs.get(Integer.valueOf(position));
+		if (o == null) {
+			return null;
+		}
 		PagerAdapter a = getAdapter();
 		View v;
 		for (int i = 0; i < getChildCount(); i++) {


### PR DESCRIPTION
Some implementations of PagerAdapter#isViewFromObject(...) such as FragmentPagerAdapter do not accept null value as object argument(which causes NPE).
