### PR TITLE
Fix pages overlapping in Stack transition effect.

### DIFF
--- a/lib/src/com/jfeinstein/jazzyviewpager/JazzyViewPager.java
+++ b/lib/src/com/jfeinstein/jazzyviewpager/JazzyViewPager.java
@@ -409,6 +409,9 @@ public class JazzyViewPager extends ViewPager {
 				ViewHelper.setScaleY(right, mScale);
 				ViewHelper.setTranslationX(right, mTrans);
 			}
+			if (left != null) {
+				left.bringToFront();
+			}
 		}
 	}
 


### PR DESCRIPTION
I fixed problem described in Issue #22. Now the right page doesn't overlap the left page when user is swiping between them.
